### PR TITLE
Fix Cloudflare Pages TypeScript build error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,81 @@
+import { join } from 'path';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Output configuration for Cloudflare Pages deployment
+  output: 'export',
+  trailingSlash: false,
+  skipTrailingSlashRedirect: true,
+  
+  // Set output file tracing root to avoid workspace detection warning
+  outputFileTracingRoot: join(process.cwd()),
+
+  // Image optimization - disabled for static export
+  images: {
+    unoptimized: true,
+  },
+
+  // Performance optimizations
+  compiler: {
+    // Remove console logs in production
+    removeConsole: process.env.NODE_ENV === 'production',
+  },
+
+  // Production optimizations
+  poweredByHeader: false,
+
+  // Experimental features for better performance
+  experimental: {
+    optimizePackageImports: ['react', 'react-dom'],
+  },
+
+  // Webpack configuration for optimization
+  webpack: (config, { isServer, dev }) => {
+    // Production optimizations
+    if (!dev && !isServer) {
+      config.optimization.splitChunks = {
+        chunks: 'all',
+        cacheGroups: {
+          default: false,
+          vendors: false,
+          framework: {
+            chunks: 'all',
+            name: 'framework',
+            test: /(?<!node_modules.*)[\\/]node_modules[\\/](react|react-dom|scheduler|prop-types|use-subscription)[\\/]/,
+            priority: 40,
+            enforce: true,
+          },
+          lib: {
+            test(module) {
+              return (
+                module.size() > 160000 &&
+                /node_modules[/\\]/.test(module.nameForCondition() || '')
+              );
+            },
+            name: 'lib',
+            priority: 30,
+            minChunks: 1,
+            reuseExistingChunk: true,
+          },
+          commons: {
+            name: 'commons',
+            minChunks: 2,
+            priority: 20,
+          },
+          shared: {
+            name: false,
+            priority: 10,
+            minChunks: 2,
+            reuseExistingChunk: true,
+          },
+        },
+        maxInitialRequests: 25,
+        minSize: 20000,
+      };
+    }
+
+    return config;
+  },
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
- Fix TypeScript dependency issue preventing Cloudflare Pages builds
- Convert next.config.ts to next.config.js to eliminate TypeScript requirement during config loading
- Maintains all existing configuration and optimizations

## Problem
- Cloudflare Pages build was failing with "Cannot find module 'typescript'" error
- next.config.ts requires TypeScript to be available during config loading phase
- TypeScript was in devDependencies which may not be installed in build environment

## Solution
- Convert next.config.ts to next.config.js using ES module syntax
- Eliminates TypeScript dependency during Next.js configuration loading
- Preserves all webpack optimizations and build settings

## Test plan
- [x] Local build succeeds (`npm run build`)
- [x] Static export generates correctly in `out/` directory
- [ ] Cloudflare Pages build succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)