### PR TITLE
Fix Cloudflare Pages Tailwind CSS dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   "dependencies": {
     "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "@tailwindcss/postcss": "^4",
+    "tailwindcss": "^4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -53,7 +54,6 @@
     "js-yaml": "^4.1.0",
     "node-fetch": "^3.3.2",
     "@types/node-fetch": "^2.6.11",
-    "tailwindcss": "^4",
     "ts-jest": "^29.1.2",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary
- Fix missing Tailwind CSS PostCSS dependency error in Cloudflare Pages production builds
- Move Tailwind CSS packages from devDependencies to dependencies

## Problem
- Production build failing with "Cannot find module '@tailwindcss/postcss'" error
- Cloudflare Pages production builds may not install devDependencies
- PostCSS requires Tailwind packages during build process

## Solution
- Move `@tailwindcss/postcss` and `tailwindcss` to dependencies
- Ensures packages are available during production build
- Maintains all Tailwind CSS functionality

## Test plan
- [x] Local build succeeds with new dependency structure
- [x] Static export generates correctly
- [ ] Cloudflare Pages production build succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)